### PR TITLE
Add Qodo PR Agent for AI-powered PR reviews

### DIFF
--- a/.github/workflows/pr_agent.yaml
+++ b/.github/workflows/pr_agent.yaml
@@ -1,0 +1,32 @@
+name: Qodo PR Agent
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+  issue_comment:
+    types: [created]
+
+jobs:
+  pr_agent:
+    if: >
+      (github.event_name == 'pull_request') ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.event.sender.type != 'Bot')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
+    name: Run Qodo PR Agent
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run PR Agent
+        uses: qodo-ai/pr-agent@main
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,55 @@
+[config]
+model = "gemini/gemini-3-flash"
+fallback_models = ["gemini/gemini-2.5-flash"]
+response_language = "en-US"
+
+[pr_reviewer]
+extra_instructions = """
+Review context: Go-based OpenShift operator (controller-runtime/kubebuilder)
+managing Shipwright Build and Shared Resource CSI Driver.
+
+Severity classification:
+  - CRITICAL: Security (RBAC escalation, credentials), data races, breaking CRD changes.
+  - HIGH: Error handling gaps, context leaks in Reconcile, missing finalizers.
+  - MEDIUM: Logging inconsistencies, Go style violations, missing unit tests.
+  - LOW: Documentation, minor refactors, naming.
+
+Focus areas:
+  - Error wrapping with fmt.Errorf("context: %w", err)
+  - Context propagation in Reconcile paths
+  - RBAC marker changes (//+kubebuilder:rbac)
+  - Manifestival transform idempotency
+  - FIPS compliance (GOEXPERIMENT=strictfipsruntime, CGO_ENABLED=1)
+  - SHA256 digest-based image references (no floating tags)
+  - No hardcoded registry URLs
+"""
+require_security_review = true
+require_tests_review = true
+require_estimate_effort_to_review = true
+num_max_findings = 15
+persistent_comment = true
+enable_review_labels_security = true
+enable_review_labels_effort = true
+enable_help_text = true
+
+[pr_code_suggestions]
+extra_instructions = """
+Go operator using controller-runtime, Go 1.24.
+Focus on: error wrapping (%w), context.Context threading,
+idempotent Reconcile logic, resource cleanup in finalizers,
+envtest/Ginkgo test patterns.
+"""
+focus_only_on_problems = true
+suggestions_score_threshold = 5
+
+[ignore]
+glob = [
+    "**/zz_generated.*",
+    "vendor/**",
+    "bundle/**",
+    "go.sum",
+    "config/crd/bases/**",
+    "hack/**",
+    "cover.out",
+    "*.json"
+]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,51 @@
+# OpenShift Builds Operator - Project Standards
+
+## Project Overview
+
+This operator deploys and manages **Shipwright Build** components and the **Shared Resource CSI Driver** on OpenShift clusters. It is built with Go 1.24, controller-runtime v0.21, and uses manifestival for declarative resource management.
+
+Key controllers:
+- `OpenShiftBuildReconciler` -- reconciles the cluster-scoped `OpenShiftBuild` CR.
+- `ShipwrightBuildReconciler` -- reconciles `ShipwrightBuild` resources.
+
+## FIPS Compliance
+
+All binaries are built with FIPS-validated cryptography:
+- `GOEXPERIMENT=strictfipsruntime`
+- `CGO_ENABLED=1`
+- Build tags: `strictfipsruntime`
+- Base images: `registry.redhat.io/ubi9/go-toolset` (build) and `ubi9-minimal` (runtime)
+
+Do not introduce non-standard crypto libraries. Use only `crypto/tls` and standard library crypto packages.
+
+## Disconnected Environment Support
+
+- All container image references use SHA256 digests (`@sha256:...`), never floating tags.
+- Images are injected via environment variables in `config/manager/manager.yaml`.
+- No hardcoded external URLs. All registry references must be overridable.
+- `USE_IMAGE_DIGESTS=true` is the default in the Makefile.
+
+## Go Coding Standards
+
+- **Error handling**: Wrap errors with context using `fmt.Errorf("operation: %w", err)`. Never silently discard errors.
+- **Context propagation**: Always thread `context.Context` through the call stack. Every `Reconcile` method receives a context; pass it to all downstream calls.
+- **Logging**: Use `logr` (via `log.FromContext(ctx)` or `ctrl.Log.WithName(...)`). The zap backend is configured in `cmd/main.go`. Do not use `klog` directly or `fmt.Print` for operational logging.
+- **Vendoring**: Dependencies are vendored (`-mod vendor`). Run `go mod vendor` after dependency changes.
+
+## Controller Patterns
+
+- **Idempotent Reconcile**: `Reconcile` must be safe to call repeatedly with the same input. Use status conditions and finalizers to track state.
+- **Manifestival**: Resources are applied via manifestival transforms. Transforms must be idempotent and must not assume prior state.
+- **envtest / Ginkgo**: Controller tests use `envtest` for a real API server and Ginkgo v2 BDD syntax (`Describe`, `When`, `It`, `BeforeEach`).
+- **RBAC markers**: Changes to `//+kubebuilder:rbac` comments affect generated ClusterRoles. Review these carefully.
+
+## Container Security
+
+- Runtime container runs as non-root: `USER 65532:65532`.
+- Security context enforces `runAsNonRoot: true`, read-only root filesystem, and drops all capabilities.
+
+## Downstream Maintenance
+
+- When modifying code synced from upstream, mark changes with `// OCP DOWNSTREAM` comments explaining the reason.
+- Never commit Secret manifests containing real credentials. Use placeholders.
+- Every PR should include unit tests. Controller logic should include envtest or integration tests.


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow (`.github/workflows/pr_agent.yaml`) to trigger Qodo PR Agent on PR open/reopen/ready_for_review and slash commands in comments
- Adds `.pr_agent.toml` with Go/OpenShift-specific review instructions, severity classification, and ignore patterns for generated/vendored files
- Adds `CLAUDE.md` with project standards (FIPS compliance, disconnected environment support, controller patterns, coding standards)
- Uses Gemini 3 Flash as the LLM backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)